### PR TITLE
Changing the h1, h2 and h3 heading colors

### DIFF
--- a/styles/catStyles.css
+++ b/styles/catStyles.css
@@ -1,7 +1,7 @@
 h1,
 h2,
 h3 {
-  color: rgba(42, 163, 165, 0.763);
+  color: rgba(1, 21, 21, 0.763);
   text-align: center;
   font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
 }


### PR DESCRIPTION
Changed the h1, h2 and h3 color to be more consistent with the background color for the cat.html page as the previous color contrast between the background and h1, h2 header colors affected its visibility.